### PR TITLE
Add contribution guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+## Submitting a Pull Request
+1. [Fork][fork] the [official repository][repo].
+2. [Create a topic branch.][branch]
+3. Implement your feature or bug fix.
+4. Add, commit, and push your changes.
+5. [Submit a pull request.][pr]
+
+[repo]: https://github.com/seanhealy/cookbook
+[fork]: https://help.github.com/articles/fork-a-repo/
+[branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
+[pr]: https://help.github.com/articles/using-pull-requests/
+
+Inspired by https://github.com/middleman/middleman-heroku/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This PR adds a base set of contribution guidelines (mostly instructions) to this repo to help future contributors know how to best provide PR's for updates.